### PR TITLE
Fixes #4813: Added rounding of position to translate3d

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -190,7 +190,7 @@ L.DomUtil = {
 		el.style[L.DomUtil.TRANSFORM] =
 			(L.Browser.ie3d ?
 				'translate(' + pos.x + 'px,' + pos.y + 'px)' :
-				'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
+				'translate3d(' + Math.round(pos.x) + 'px,' + Math.round(pos.y) + 'px,0)') +
 			(scale ? ' scale(' + scale + ')' : '');
 	},
 


### PR DESCRIPTION
Chrome renders half pixels when doing CSS transforms, which can make the tooltips blurry when the tooltip has an uneven hight or width.

`Math.round()` could also be added to the `layer/Tooltip.js` directly in the [_setPosition](https://github.com/Leaflet/Leaflet/blob/master/src/layer/Tooltip.js#L124), but I prefer handling exact numbers within the code and only rounding when rendering.